### PR TITLE
Use f-string for job info display

### DIFF
--- a/fergus_gui_with_job_validation.py
+++ b/fergus_gui_with_job_validation.py
@@ -187,13 +187,10 @@ def show_job_info(job_number):
         job_info_label.config(text="❌ Job not found.")
     else:
         info_text = (
-            "Job No: {job_info['jobNo']}
-"
-            "Description: {job_info['description']}
-"
-            "Customer: {job_info['customer']}
-"
-            "Quote Accepted: {'✅ Yes' if job_info['quoteAccepted'] else '❌ No'}"
+            f"Job No: {job_info['jobNo']}\n"
+            f"Description: {job_info['description']}\n"
+            f"Customer: {job_info['customer']}\n"
+            f"Quote Accepted: {'✅ Yes' if job_info['quoteAccepted'] else '❌ No'}"
         )
         job_info_label.config(text=info_text)
 


### PR DESCRIPTION
## Summary
- Replace tuple assignment with newline-separated f-string in `show_job_info`

## Testing
- `python -m py_compile fergus_gui_with_job_validation.py`


------
https://chatgpt.com/codex/tasks/task_e_68901e3a96148321a8837700020998b2