### PR TITLE
Fix success popup centering with actual geometry

### DIFF
--- a/FergusQuoteUploader (10).py
+++ b/FergusQuoteUploader (10).py
@@ -270,7 +270,11 @@ def push_quote(job_id, title, items, quote_id=None, job_no_for_web=None, parent=
         ttk.Label(popup, text="✅ Quote submitted successfully.\nOpening Fergus…").pack(padx=20, pady=20)
         # Center and raise popup (non-blocking)
         popup.update_idletasks()
-        w, h = popup.winfo_reqwidth(), popup.winfo_reqheight()
+        w, h = popup.winfo_width(), popup.winfo_height()
+        if w <= 1:
+            w = popup.winfo_reqwidth()
+        if h <= 1:
+            h = popup.winfo_reqheight()
         if parent:
             parent.update_idletasks()
             px, py = parent.winfo_rootx(), parent.winfo_rooty()
@@ -287,7 +291,7 @@ def push_quote(job_id, title, items, quote_id=None, job_no_for_web=None, parent=
             sw, sh = popup.winfo_screenwidth(), popup.winfo_screenheight()
             x, y = (sw - w)//2, (sh - h)//3
 
-        popup.geometry(f"+{x}+{y}")
+        popup.geometry(f"{int(w)}x{int(h)}+{int(x)}+{int(y)}")
 
         try:
             popup.attributes("-topmost", True)


### PR DESCRIPTION
## Summary
- use the popup's realized dimensions when centering the success dialog, falling back to requested metrics as needed
- specify the width and height in the geometry string to keep the window manager from resizing after centering

## Testing
- not run (requires Windows environment)


------
https://chatgpt.com/codex/tasks/task_e_68dda49d69c48321afab78293f0f8bc5