### PR TITLE
Center success popup on screen

### DIFF
--- a/FergusQuoteUploader (10).py
+++ b/FergusQuoteUploader (10).py
@@ -276,20 +276,14 @@ def push_quote(job_id, title, items, quote_id=None, job_no_for_web=None, parent=
         if h <= 1:
             h = popup.winfo_reqheight()
         if parent:
-            parent.update_idletasks()
-            px, py = parent.winfo_rootx(), parent.winfo_rooty()
-            pw, ph = parent.winfo_width(), parent.winfo_height()
-            if pw <= 1 or ph <= 1:
-                pw, ph = parent.winfo_reqwidth(), parent.winfo_reqheight()
-            x = px + (pw - w)//2
-            y = py + (ph - h)//2
             try:
                 popup.transient(parent)
             except Exception as transient_error:
                 print(f"⚠️ Failed to mark popup transient: {transient_error}")
-        else:
-            sw, sh = popup.winfo_screenwidth(), popup.winfo_screenheight()
-            x, y = (sw - w)//2, (sh - h)//3
+
+        sw, sh = popup.winfo_screenwidth(), popup.winfo_screenheight()
+        x = max((sw - w) // 2, 0)
+        y = max((sh - h) // 2, 0)
 
         popup.geometry(f"{int(w)}x{int(h)}+{int(x)}+{int(y)}")
 


### PR DESCRIPTION
## Summary
- center the Fergus submission success popup using screen dimensions so it always appears in the middle of the display
- retain transient behavior when a parent window exists while ensuring consistent geometry

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dda6667da88321af43ddf44bed9ceb